### PR TITLE
Fix #83. Parsing the milliseconds from timestamp of testing data

### DIFF
--- a/AggregateTester/TestDataHelpers.cs
+++ b/AggregateTester/TestDataHelpers.cs
@@ -395,12 +395,20 @@ namespace Quickstarts
                 throw new FormatException("The minute must be less than 60.'");
             }
 
-            double seconds = Convert.ToDouble(fields[2]);
-            timestamp = timestamp.AddSeconds(seconds);
+            var secondsWithMs = fields[2].Split('.');
 
+            double seconds = Convert.ToDouble(secondsWithMs[0]);
+            timestamp = timestamp.AddSeconds(seconds);
+            
             if (seconds > 60)
             {
                 throw new FormatException("The second must be less than 60.'");
+            }
+
+            if (secondsWithMs.Length == 2)
+            {
+                double milliseconds = Convert.ToDouble(secondsWithMs[1]);
+                timestamp.AddMilliseconds(milliseconds);
             }
 
             return timestamp;


### PR DESCRIPTION
This fix will avoid the FormatException when loading the Test Data on the Aggregate Tester.
Now the milliseconds part of the string is being parsed and applied to the generated DateTime value.